### PR TITLE
Made the library work in PHP 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "jcook/react-amqp",
+    "name": "ovimihai/react-amqp",
     "description": "AMQP bindings for ReactPHP",
     "keywords": ["amqp", "rabbitmq"],
     "license": "MIT",
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.3.0",
         "ext-amqp": "*",
         "evenement/evenement": "1.0.*",
         "react/event-loop": "0.3.*"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ovimihai/react-amqp",
+    "name": "jcook/react-amqp",
     "description": "AMQP bindings for ReactPHP",
     "keywords": ["amqp", "rabbitmq"],
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "jcook/react-amqp",
+    "name": "ovimihai/react-amqp",
     "description": "AMQP bindings for ReactPHP",
     "keywords": ["amqp", "rabbitmq"],
     "license": "MIT",

--- a/src/JCook/ReactAMQP/Consumer.php
+++ b/src/JCook/ReactAMQP/Consumer.php
@@ -75,7 +75,7 @@ class Consumer extends EventEmitter
         }
         $counter = 0;
         while ($envelope = $this->queue->get()) {
-            $this->emit('consume', [$envelope, $this->queue]);
+            $this->emit('consume', array($envelope, $this->queue));
             if ($this->max && ++$counter >= $this->max) {
                 return;
             }
@@ -92,7 +92,7 @@ class Consumer extends EventEmitter
      */
     public function __call($method, $args)
     {
-        return call_user_func_array([$this->queue, $method], $args);
+        return call_user_func_array(array($this->queue, $method), $args);
     }
 
     /**
@@ -104,7 +104,7 @@ class Consumer extends EventEmitter
             return;
         }
 
-        $this->emit('end', [$this]);
+        $this->emit('end', array($this));
         $this->loop->cancelTimer($this->timer);
         $this->removeAllListeners();
         unset($this->queue);

--- a/src/JCook/ReactAMQP/Producer.php
+++ b/src/JCook/ReactAMQP/Producer.php
@@ -91,17 +91,17 @@ class Producer extends EventEmitter implements Countable, IteratorAggregate
      *
      * @throws BadMethodCallException
      */
-    public function publish($message, $routingKey, $flags = null, $attributes = [])
+    public function publish($message, $routingKey, $flags = null, $attributes = array())
     {
         if ($this->closed) {
             throw new BadMethodCallException('This Producer object is closed and cannot send any more messages.');
         }
-        $this->messages[] = [
+        $this->messages[] = array(
             'message'    => $message,
             'routingKey' => $routingKey,
             'flags'      => $flags,
             'attributes' => $attributes
-        ];
+        );
     }
 
     /**
@@ -120,7 +120,7 @@ class Producer extends EventEmitter implements Countable, IteratorAggregate
                 unset($this->messages[$key]);
                 $this->emit('produce', $message);
             } catch (AMQPExchangeException $e) {
-                $this->emit('error', [$e]);
+                $this->emit('error', array($e));
             }
         }
     }
@@ -135,7 +135,7 @@ class Producer extends EventEmitter implements Countable, IteratorAggregate
      */
     public function __call($method, $args)
     {
-        return call_user_func_array([$this->exchange, $method], $args);
+        return call_user_func_array(array($this->exchange, $method), $args);
     }
 
     /**
@@ -147,7 +147,7 @@ class Producer extends EventEmitter implements Countable, IteratorAggregate
             return;
         }
 
-        $this->emit('end', [$this]);
+        $this->emit('end', array($this));
         $this->loop->cancelTimer($this->timer);
         $this->removeAllListeners();
         unset($this->exchange);

--- a/tests/JCook/ReactAMQP/Tests/ConsumerTest.php
+++ b/tests/JCook/ReactAMQP/Tests/ConsumerTest.php
@@ -178,9 +178,9 @@ class ConsumerTest extends PHPUnit_Framework_TestCase
     public static function IntervalMaxSupplier()
     {
         return array(
-            [1, null],
-            [1, 1],
-            [0.05, 10],
+            array(1, null),
+            array(1, 1),
+            array(0.05, 10),
         );
     }
 
@@ -191,9 +191,9 @@ class ConsumerTest extends PHPUnit_Framework_TestCase
     public static function MaxSupplier()
     {
         return array(
-            [1],
-            [10],
-            [45]
+            array(1),
+            array(10),
+            array(45)
         );
     }
 
@@ -205,9 +205,9 @@ class ConsumerTest extends PHPUnit_Framework_TestCase
     public static function CallSupplier()
     {
         return array(
-            ['getArgument', 'foo'],
-            ['nack', 'bar'],
-            ['cancel', 'baz']
+            array('getArgument', 'foo'),
+            array('nack', 'bar'),
+            array('cancel', 'baz')
         );
     }
 }

--- a/tests/JCook/ReactAMQP/Tests/ProducerTest.php
+++ b/tests/JCook/ReactAMQP/Tests/ProducerTest.php
@@ -254,9 +254,9 @@ class ProducerTest extends PHPUnit_Framework_TestCase
     public static function IntervalSupplier()
     {
         return array(
-            [1],
-            [2.4],
-            [0.05]
+            array(1),
+            array(2.4),
+            array(0.05)
         );
     }
 
@@ -267,8 +267,8 @@ class ProducerTest extends PHPUnit_Framework_TestCase
     public static function MessageProvider()
     {
         return array(
-            ['foo', 'bar', 1 & 1, []],
-            ['bar', 'baz', 1 & 0, ['foo' => 'bar']]
+            array('foo', 'bar', 1 & 1, array()),
+            array('bar', 'baz', 1 & 0, array('foo' => 'bar'))
         );
     }
 
@@ -279,10 +279,10 @@ class ProducerTest extends PHPUnit_Framework_TestCase
     public static function MessagesProvider()
     {
         return array(
-            [[
-            ['foo', 'bar', 1 & 1, []],
-            ['bar', 'baz', 1 & 0, ['foo' => 'bar']]
-            ]]
+            array(array(
+                array('foo', 'bar', 1 & 1, array()),
+                array('bar', 'baz', 1 & 0, array('foo' => 'bar'))
+            ))
         );
     }
 
@@ -293,8 +293,8 @@ class ProducerTest extends PHPUnit_Framework_TestCase
     public static function CallProvider()
     {
         return array(
-            ['setName', 'foo'],
-            ['setType', 'bar']
+            array('setName', 'foo'),
+            array('setType', 'bar')
         );
     }
 }


### PR DESCRIPTION
The library can work in PHP 5.3 with a simple replacement of the [] notations of arrays.
The other dependencies already work with PHP 5.3
